### PR TITLE
Unbreak Aeron Python

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,10 +1,10 @@
 Metadata-Version: 1.0
 Name: aeron_python
-Version: 1.0.1
+Version: 1.0.2
 Summary: Python bindings for Aeron
 Home-page: https://github.com/fairtide/aeron-python
 Author: Fairtide Pte
 Author-email: UNKNOWN
 License: Apache 2.0
-Description: Python binfings for Aeron messaging
+Description: Python bindings for Aeron messaging
 Platform: UNKNOWN

--- a/sources/package/aeronpy/_subscription.hpp
+++ b/sources/package/aeronpy/_subscription.hpp
@@ -89,9 +89,7 @@ public:
 private:
     std::shared_ptr<aeron::Subscription> aeron_subscription_;
 
-    pybind11::function py_func_handler;
-
     std::shared_ptr<aeron::ControlledFragmentAssembler> fragmentAssembler_ = nullptr;
 
-    void init_fragment_assembler();
+    void init_fragment_assembler(pybind11::function handler);
 };


### PR DESCRIPTION
We noticed that a segmentation fault occurred in Python threading setup and was introduced in the last PR. i think it has to do with Python object reference count. Here is an attempt to fix it. It works on my setup with publishing & subscribing both small protobuf packets and big image packets. @shoelick or @ChartierLuc please try it on your end and let me know if it works. Note this version is 1.0.2